### PR TITLE
Improve API requirement parsing

### DIFF
--- a/app/Services/GPTChatService.php
+++ b/app/Services/GPTChatService.php
@@ -242,7 +242,8 @@ class GPTChatService
         Log::info('🔍 Extracting API requirements from GPT response');
         
         // Extract city and date from the format: 🔍 REQUIERE_API: ciudad=[...], fecha=[...]
-        if (!preg_match('/🔍 REQUIERE_API: ciudad=\[([^\]]+)\], fecha=\[([^\]]+)\]/', $response, $matches)) {
+        // The brackets are optional to make the parser more tolerant
+        if (!preg_match('/🔍\s*REQUIERE_API:\s*ciudad=\[?([^\],]+)\]?,\s*fecha=\[?([^\]\.,]+)\]?/i', $response, $matches)) {
             Log::error('❌ Invalid API requirement format in GPT response', [
                 'response_preview' => substr($response, 0, 200),
                 'pattern_not_found' => true

--- a/docs/GPTChatService.md
+++ b/docs/GPTChatService.md
@@ -186,6 +186,11 @@ If GPT determines it needs external data, it responds with:
 ```
 🔍 REQUIERE_API: ciudad=[Madrid], fecha=[mañana]
 ```
+The brackets around the values are recommended but optional. The system will
+also accept responses like:
+```
+🔍 REQUIERE_API: ciudad=Madrid, fecha=hoy
+```
 
 The system then:
 1. Extracts city and date requirements

--- a/tests/Feature/GPTChatServiceTest.php
+++ b/tests/Feature/GPTChatServiceTest.php
@@ -272,4 +272,19 @@ class GPTChatServiceTest extends TestCase
             'date' => 'mañana'
         ], $result);
     }
-} 
+
+    public function test_extract_api_requirements_without_brackets()
+    {
+        $reflection = new \ReflectionClass($this->gptChatService);
+        $method = $reflection->getMethod('extractApiRequirements');
+        $method->setAccessible(true);
+
+        $response = "🔍 REQUIERE_API: ciudad=Madrid, fecha=hoy.";
+        $result = $method->invoke($this->gptChatService, $response);
+
+        $this->assertEquals([
+            'city' => 'Madrid',
+            'date' => 'hoy'
+        ], $result);
+    }
+}


### PR DESCRIPTION
## Summary
- support optional brackets when extracting API requirements
- describe optional bracket format in docs
- test extraction with and without brackets

## Testing
- `php artisan test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685d891791d48331bf3ea6c4d5fabe21